### PR TITLE
Feature - Export JSON data of current view

### DIFF
--- a/src/app/visualize/page.tsx
+++ b/src/app/visualize/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
-import { useGraphStore } from '@/store/useGraphStore';
+import { useGraphStore, type ExportedNode } from '@/store/useGraphStore';
 import ExportModal from '@/components/ExportModal';
 
 // Import LineageGraph dynamically to avoid SSR issues with ReactFlow
@@ -21,7 +21,7 @@ export default function VisualizePage() {
   const { nodes, projectName, searchQuery, setSearchQuery, exportNodesData, getFilteredNodes } = useGraphStore();
   const [mounted, setMounted] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
-  const [exportData, setExportData] = useState<any[]>([]);
+  const [exportData, setExportData] = useState<ExportedNode[]>([]);
 
   useEffect(() => {
     setMounted(true);

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState } from 'react';
+import type { ExportedNode } from '@/store/useGraphStore';
 
 interface ExportModalProps {
   isOpen: boolean;
   onClose: () => void;
-  data: any[];
+  data: ExportedNode[];
 }
 
 export default function ExportModal({ isOpen, onClose, data }: ExportModalProps) {

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import { useGraphStore } from '@/store/useGraphStore';
-import { nodeColors } from '@/lib/graphBuilder';
+import { nodeColors, type GraphNode } from '@/lib/graphBuilder';
 
 const RESOURCE_TYPES = [
   { type: 'model', label: 'Models', color: nodeColors.model },
@@ -30,7 +30,7 @@ export default function FilterBar() {
   // Extract all unique tags from nodes
   const allTags = useMemo(() => {
     const tagSet = new Set<string>();
-    nodes.forEach((node) => {
+    nodes.forEach((node: GraphNode) => {
       node.data.tags?.forEach((tag) => tagSet.add(tag));
     });
     return Array.from(tagSet).sort();
@@ -39,7 +39,7 @@ export default function FilterBar() {
   // Extract all unique inferred tags from nodes
   const allInferredTags = useMemo(() => {
     const tagSet = new Set<string>();
-    nodes.forEach((node) => {
+    nodes.forEach((node: GraphNode) => {
       node.data.inferredTags?.forEach((tag) => tagSet.add(tag));
     });
     return Array.from(tagSet).sort();
@@ -213,7 +213,7 @@ export default function FilterBar() {
               <div className="flex items-center gap-2">
                 <span>Resources:</span>
                 <div className="flex items-center gap-1">
-                  {Array.from(resourceTypeFilters).map((type) => {
+                  {(Array.from(resourceTypeFilters) as string[]).map((type) => {
                     const resource = RESOURCE_TYPES.find((r) => r.type === type);
                     if (!resource) return null;
                     return (
@@ -234,7 +234,7 @@ export default function FilterBar() {
                 <div className="flex items-center gap-2">
                   <span>Tags:</span>
                   <div className="flex items-center gap-1">
-                    {Array.from(tagFilters).map((tag) => (
+                    {(Array.from(tagFilters) as string[]).map((tag) => (
                       <span
                         key={tag}
                         className="px-2 py-1 rounded bg-slate-500 text-white text-xs font-medium"
@@ -251,7 +251,7 @@ export default function FilterBar() {
                 <div className="flex items-center gap-2">
                   <span>Inferred:</span>
                   <div className="flex items-center gap-1">
-                    {Array.from(inferredTagFilters).map((tag) => (
+                    {(Array.from(inferredTagFilters) as string[]).map((tag) => (
                       <span
                         key={tag}
                         className="px-2 py-1 rounded bg-amber-500 text-white text-xs font-medium"

--- a/src/components/LineageGraph.tsx
+++ b/src/components/LineageGraph.tsx
@@ -369,7 +369,7 @@ function LineageGraphInner() {
             <div className="mb-4">
               <h4 className="text-sm font-semibold text-gray-700 mb-2">Inferred Layer</h4>
               <div className="flex flex-wrap gap-2">
-                {selectedNode.data.inferredTags.map((tag) => (
+                {selectedNode.data.inferredTags.map((tag: string) => (
                   <span
                     key={tag}
                     className="px-2 py-1 bg-amber-100 text-amber-800 text-xs rounded-md font-medium"
@@ -385,7 +385,7 @@ function LineageGraphInner() {
             <div className="mb-4">
               <h4 className="text-sm font-semibold text-gray-700 mb-2">Tags</h4>
               <div className="flex flex-wrap gap-2">
-                {selectedNode.data.tags.map((tag) => (
+                {selectedNode.data.tags.map((tag: string) => (
                   <span
                     key={tag}
                     className="px-2 py-1 bg-slate-100 text-slate-700 text-xs rounded-md font-medium"

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -1,6 +1,18 @@
 import { create } from 'zustand';
 import type { GraphNode, GraphEdge } from '@/lib/graphBuilder';
 import type { ParsedManifest } from '@/lib/manifestParser';
+import { filterNodes } from '@/lib/graphBuilder';
+
+export interface ExportedNode {
+  id: string;
+  name: string;
+  type: string;
+  inferredLayer: string | null;
+  database?: string;
+  schema?: string;
+  description?: string;
+  tags: string[];
+}
 
 export type GraphStore = {
   // Graph data
@@ -33,11 +45,11 @@ export type GraphStore = {
   toggleInferredTag: (tag: string) => void;
   setInferredTagFilterMode: (mode: 'AND' | 'OR') => void;
   clearGraph: () => void;
-  exportNodesData: (nodesToExport?: GraphNode[]) => any[];
+  exportNodesData: (nodesToExport?: GraphNode[]) => ExportedNode[];
   getFilteredNodes: () => GraphNode[];
 };
 
-export const useGraphStore = create<GraphStore>((set) => ({
+export const useGraphStore = create<GraphStore>((set, get) => ({
   // Initial state
   nodes: [],
   edges: [],
@@ -154,7 +166,7 @@ export const useGraphStore = create<GraphStore>((set) => ({
     }),
 
   exportNodesData: (nodesToExport) => {
-    const state = useGraphStore.getState();
+    const state = get();
     const nodes = nodesToExport || state.nodes;
     return nodes.map((node) => ({
       id: node.id,
@@ -169,9 +181,9 @@ export const useGraphStore = create<GraphStore>((set) => ({
   },
 
   getFilteredNodes: () => {
-    const state = useGraphStore.getState();
+    const state = get();
     const { nodes, edges, searchQuery, resourceTypeFilters, tagFilters, tagFilterMode, inferredTagFilters } = state;
-    const filtered = require('@/lib/graphBuilder').filterNodes(
+    const filtered = filterNodes(
       nodes,
       edges,
       searchQuery,


### PR DESCRIPTION
This pull request adds a new feature that allows users to export the currently visualized graph data as JSON from the `VisualizePage`. It introduces an export button and a modal for copying the exported data, along with the necessary logic to generate the export data from the graph store.

**New Export Functionality:**

* Added an `Export Data` button to the `VisualizePage` header, allowing users to export the currently visualized nodes.
* Introduced a new `ExportModal` component that displays the exported JSON, allows users to copy it to the clipboard, and provides feedback on successful copy.
* Updated the `useGraphStore` store with a new `exportNodesData` method that prepares the relevant node data for export. [[1]](diffhunk://#diff-1b7b61b89dd794257e02e425a756f5d6868588a6e62ad26aa8756026b5fb4526R36) [[2]](diffhunk://#diff-1b7b61b89dd794257e02e425a756f5d6868588a6e62ad26aa8756026b5fb4526R154-R167)

**Integration and UI Adjustments:**

* Integrated the export logic and modal state into the `VisualizePage` component, including handling button clicks and modal visibility. [[1]](diffhunk://#diff-0ce845bdd56ccffce828a82555460b455f31f2aa6f6a364701e1f2427bc5f86fL20-R24) [[2]](diffhunk://#diff-0ce845bdd56ccffce828a82555460b455f31f2aa6f6a364701e1f2427bc5f86fR37-R42)
* Replaced the previous legend in the header with the new export button for a cleaner UI.
* Imported the new `ExportModal` component into the page for use.